### PR TITLE
fix(loki): fix binary index in batch updates when not cloning

### DIFF
--- a/packages/loki/spec/generic/binaryidx.spec.ts
+++ b/packages/loki/spec/generic/binaryidx.spec.ts
@@ -323,6 +323,54 @@ describe("binary indices", () => {
     });
   });
 
+  describe("adaptiveBinaryIndex batch updates work", () => {
+    it("works", function() {
+      const db = new Loki("idxtest");
+      const items = db.addCollection<{a: number, b:boolean}>("items", {
+        adaptiveBinaryIndices: true,
+        indices: ["b"]
+      });
+
+      // init 4 docs with bool 'b' all false
+      const docs = [{a:8000, b:false}, {a:6000, b:false}, {a:4000, b: false}, {a:2000, b:false}];
+
+      items.insert(docs);
+
+      // update two docs to have 'b' true
+      let results = items.find({a: {$in: [8000, 6000]}});
+      results.forEach(function(obj) {
+        obj.b = true;
+      });
+      items.update(results);
+
+      // should be 2 of each
+      expect(items.find({b: true}).length).toEqual(2);
+      expect(items.find({b: false}).length).toEqual(2);
+
+      // reset all bool 'b' props to false
+      results = items.find({b: true});
+      results.forEach(function(obj) {
+        obj.b = false;
+      });
+      items.update(results);
+
+      // should be no true and 4 false
+      expect(items.find({b: true}).length).toEqual(0);
+      expect(items.find({b: false}).length).toEqual(4);
+
+      // update different 2 to be true
+      results = items.find({a: {$in: [8000, 2000]}});
+      results.forEach(function(obj) {
+        obj.b = true;
+      });
+      items.update(results);
+
+      // should be 2 true and 2 false
+      expect(items.find({b: true}).length).toEqual(2);
+      expect(items.find({b: false}).length).toEqual(2);
+    });
+  });
+
   describe("adaptiveBinaryIndexRemove works", () => {
     it("works", () => {
 


### PR DESCRIPTION
Batch updates will now temporarily disable adaptive indices (when not cloning) for the duration of the batch update if binary indices are defined.  We will do a full lazy rebuild when batch update completes and re-enable adaptive indices.  This fixes edge case where binary indices could become corrupt.  If your batches are small or medium sized it will likely be faster to update docs individually, as they are modified instead.

See techfort/LokiJS@0178e9d03e4fdef87dfa4bb008b809b47caa7614

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/LokiJS-Forge/LokiJS2/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
