### PR TITLE
feat(loki): simplesort leverages binary indices better when filtered

### DIFF
--- a/packages/loki/spec/generic/transforms.spec.ts
+++ b/packages/loki/spec/generic/transforms.spec.ts
@@ -270,7 +270,7 @@ describe("transforms", () => {
         {
           type: "simplesort",
           property: "a",
-          desc: true
+          options: true
         },
         {
           type: "limit",

--- a/packages/loki/src/collection.ts
+++ b/packages/loki/src/collection.ts
@@ -2170,7 +2170,7 @@ export namespace Collection {
   } | {
     type: "simplesort";
     property: keyof (TData & TNested);
-    desc?: boolean;
+    options?: boolean | ResultSet.SimpleSortOptions;
   } | {
     type: "compoundsort";
     value: (keyof (TData & TNested) | [keyof (TData & TNested), boolean])[];


### PR DESCRIPTION
array intersection algorithm is used to leverage binary index on simplesort if you have filtered out at least 10% of total documents from results

See techfort/LokiJS@4e28e8183aa1d2fa529e8d19a0a805923d11a650

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/LokiJS-Forge/LokiJS2/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
